### PR TITLE
fixed: run.gif not loading in readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Run the python script::
         python3 nameofthescript.py
 
 
-.. image:: ./assets/run.gif
+.. image:: ../assets/run.gif
 
 Roadmap
 --------


### PR DESCRIPTION
the path for run.gif has been updated to ../assets/run.gif. I've tested it on my local machine too and it's working perfectly fine.